### PR TITLE
Load position improvements

### DIFF
--- a/OpenSpaceToolbox/ViewModels/Bookmarks/BookmarksViewModel.cs
+++ b/OpenSpaceToolbox/ViewModels/Bookmarks/BookmarksViewModel.cs
@@ -235,7 +235,7 @@ namespace OpenSpaceToolbox
             if (SelectedBookmark == null)
                 return;
 
-            GameManager.PlayerCoordinates = (SelectedBookmark.X, SelectedBookmark.Y, SelectedBookmark.Z);
+            GameManager.PlayerCoordinates = GameManager.SavedPosition = (SelectedBookmark.X, SelectedBookmark.Y, SelectedBookmark.Z);
         }
 
         /// <summary>
@@ -318,6 +318,8 @@ namespace OpenSpaceToolbox
 
             AllBookmarkItems.Add(bookmark);
             BookmarkItems.Add(bookmark);
+
+            GameManager.SavedPosition = coords;
         }
 
         /// <summary>

--- a/OpenSpaceToolbox/ViewModels/GameManagerViewModel.cs
+++ b/OpenSpaceToolbox/ViewModels/GameManagerViewModel.cs
@@ -78,6 +78,9 @@ namespace OpenSpaceToolbox
         /// </summary>
         public void LoadSavedPosition()
         {
+            if (GameManager.SavedPosition == default)
+                return;
+
             GameManager.PlayerCoordinates = GameManager.SavedPosition;
         }
 

--- a/OpenSpaceToolbox/Views/GameManagerFullView.xaml.cs
+++ b/OpenSpaceToolbox/Views/GameManagerFullView.xaml.cs
@@ -16,8 +16,10 @@ namespace OpenSpaceToolbox
         private void BookmarkListItemDoubleClick(object sender, MouseButtonEventArgs e)
         {
             if (DataContext is MainViewModel viewModel)
-                viewModel.GameManager.PlayerCoordinates = (viewModel.BookmarksVm.SelectedBookmark.X,
-                    viewModel.BookmarksVm.SelectedBookmark.Y, viewModel.BookmarksVm.SelectedBookmark.Z);
+                viewModel.GameManager.PlayerCoordinates = viewModel.GameManager.SavedPosition =
+                    (viewModel.BookmarksVm.SelectedBookmark.X,
+                    viewModel.BookmarksVm.SelectedBookmark.Y,
+                    viewModel.BookmarksVm.SelectedBookmark.Z);
         }
 
         private void LevelTreeItemDoubleClick(object sender, MouseButtonEventArgs e)

--- a/OpenSpaceToolbox/Views/GameManagerMinimizedView.xaml.cs
+++ b/OpenSpaceToolbox/Views/GameManagerMinimizedView.xaml.cs
@@ -16,8 +16,10 @@ namespace OpenSpaceToolbox
         private void BookmarkListItemDoubleClick(object sender, MouseButtonEventArgs e)
         {
             if (DataContext is MainViewModel viewModel)
-                viewModel.GameManager.PlayerCoordinates = (viewModel.BookmarksVm.SelectedBookmark.X,
-                    viewModel.BookmarksVm.SelectedBookmark.Y, viewModel.BookmarksVm.SelectedBookmark.Z);
+                viewModel.GameManager.PlayerCoordinates = viewModel.GameManager.SavedPosition =
+                    (viewModel.BookmarksVm.SelectedBookmark.X,
+                    viewModel.BookmarksVm.SelectedBookmark.Y,
+                    viewModel.BookmarksVm.SelectedBookmark.Z);
         }
 
         private void LevelTreeItemDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
- Adding/loading a bookmark sets it as the new saved position
- Prevent getting teleported at 0,0,0 when there's no saved position